### PR TITLE
fix: use pixelated image-rendering for sprites

### DIFF
--- a/app/components.js
+++ b/app/components.js
@@ -16,6 +16,7 @@ export function Pokemon({ id, name }) {
         height={96}
         alt={name}
         src={`https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/${id}.png`}
+        className="rendering-pixelated"
       />
       {name}
     </li>

--- a/app/components.js
+++ b/app/components.js
@@ -17,6 +17,7 @@ export function Pokemon({ id, name }) {
         alt={name}
         src={`https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/${id}.png`}
         className="rendering-pixelated"
+        unoptimized
       />
       {name}
     </li>

--- a/app/globals.css
+++ b/app/globals.css
@@ -25,3 +25,7 @@ body {
     )
     rgb(var(--background-start-rgb));
 }
+
+.rendering-pixelated {
+  image-rendering: pixelated;
+}


### PR DESCRIPTION
While it may not be a crime to put SQL queries directly into React components, it _is_ a crime against Pokemon trainers everywhere to render sprites without `image-rendering: pixelated`. This PR fixes that in addition to disabling the lossy conversion that `next/image` introduces by passing the source image through `unoptimized` (can [this be fixed plz](https://github.com/vercel/next.js/issues/32106)).

### Before

<img width="615" alt="Screenshot 2023-11-11 172906" src="https://github.com/rauchg/how-is-this-not-illegal/assets/88163/9c4617c9-c782-4368-9410-b7f403a1278d">

### After

<img width="626" alt="Screenshot 2023-11-11 172846" src="https://github.com/rauchg/how-is-this-not-illegal/assets/88163/20656195-2dbd-4f45-9fb7-47420a0ffd98">
